### PR TITLE
Add konflux Dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,61 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.22.5-202407301728.gd58751c.el8 AS builder
+
+RUN dnf module install -y nodejs:16/development
+ENV NPM_CONFIG_NODEDIR=/usr
+
+RUN yum install -y --setopt=tsflags=nodocs bzip2 jq golang-github-prometheus-promu
+
+COPY $REMOTE_SOURCES/ $REMOTE_SOURCES_DIR/
+
+WORKDIR ${REMOTE_SOURCES_DIR:-/remote_sources}/prometheus/app
+
+ENV GOFLAGS='-mod=mod'
+ARG GO_BIN=$REMOTE_SOURCES_DIR/prometheus/deps/gomod/bin
+
+# Move the prometheus-promu we install to go's bin/ to avoid re-installing it during the build
+# Makefile.common expects the promu binary in a certain location
+RUN source ../cachito.env \
+    && mkdir $GO_BIN \
+    && ln -s $(which promu) $GO_BIN/promu \
+    && make build
+
+FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1086
+
+WORKDIR /
+
+ARG FROM_DIRECTORY=${REMOTE_SOURCES_DIR}/prometheus/app
+COPY --from=builder ${FROM_DIRECTORY}/prometheus                            /bin/prometheus
+COPY --from=builder ${FROM_DIRECTORY}/promtool                              /bin/promtool
+COPY --from=builder ${FROM_DIRECTORY}/documentation/examples/prometheus.yml /etc/prometheus/prometheus.yml
+COPY --from=builder ${FROM_DIRECTORY}/console_libraries/                    /usr/share/prometheus/console_libraries/
+COPY --from=builder ${FROM_DIRECTORY}/consoles/                             /usr/share/prometheus/consoles/
+
+RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
+RUN mkdir -p /prometheus && \
+    chgrp -R 0 /etc/prometheus /prometheus && \
+    chmod -R g=u /etc/prometheus /prometheus
+
+# cleanup after build.
+RUN rm -rf ${REMOTE_SOURCES_DIR}
+
+USER       nobody
+EXPOSE     9090
+WORKDIR    /prometheus
+VOLUME     ["/prometheus"]
+ENTRYPOINT ["/bin/prometheus"]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+             "--storage.tsdb.path=/prometheus", \
+             "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+             "--web.console.templates=/usr/share/prometheus/consoles" ]
+
+LABEL com.redhat.component="coo-prometheus-container" \
+      name="prometheus/prometheus" \
+      version="v2.54.1" \
+      upstream-version="${CI_OBO_PROMETHEUS_UPSTREAM_VERSION}" \
+      upstream-vcs-ref="${CI_OBO_PROMETHEUS_UPSTREAM_COMMIT}" \
+      summary="Prometheus for Cluster Observability Operator" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="monitoring" \
+      io.k8s.display-name="COO Prometheus" \
+      maintainer="team-monitoring@redhat.com" \
+      description="Prometheus for Cluster Observability Operator"


### PR DESCRIPTION
This PR creates a new Dockefile at the obo-prometheus fork, tailored for konflux builds.
